### PR TITLE
🛡️ Sentinel: [HIGH] Fix clickjacking vulnerability

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -3,3 +3,8 @@
 **Vulnerability:** Game state corruption via unvalidated `localStorage` high score values (e.g., negative numbers, NaN).
 **Learning:** Data retrieved from client-side storage should be treated as untrusted user input and verified.
 **Prevention:** Use `parseInt(data, 10)` and apply proper validation checks (e.g., `!isNaN`, `value >= 0`) before using data retrieved from `localStorage`.
+
+## 2024-05-25 - Client-Side Framebusting for Static Apps
+**Vulnerability:** Clickjacking (UI redressing) due to missing `frame-ancestors` CSP directive.
+**Learning:** For static applications that lack server-side HTTP response header configurations, CSP `frame-ancestors` cannot be enforced via `<meta>` tags.
+**Prevention:** Implement client-side JavaScript framebusting logic (`if (window.top !== window.self) { window.top.location.replace(window.self.location.href); }`) to prevent the application from being embedded in an iframe.

--- a/script.js
+++ b/script.js
@@ -1,3 +1,9 @@
+// Mitigate clickjacking (UI redressing) by preventing the page from being framed.
+// Necessary because CSP frame-ancestors is ignored in <meta> tags.
+if (window.top !== window.self) {
+  window.top.location = window.self.location;
+}
+
 const canvas = document.getElementById("gameCanvas");
 const ctx = canvas.getContext("2d");
 const playAgainBtn = document.getElementById("playAgainBtn");


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** Clickjacking (UI redressing) due to missing `frame-ancestors` CSP directive. Static HTML files cannot set this via `<meta>` tags.
🎯 **Impact:** An attacker could embed the game within an iframe on a malicious site, potentially tricking users into interacting with the game unknowingly or extracting data if there were sensitive elements.
🔧 **Fix:** Added a robust client-side framebusting script to the very top of `script.js` to detect if the page is being framed and, if so, force the top window to navigate to the game's actual URL.
✅ **Verification:** Verified that existing Playwright tests continue to pass without errors and manually verified via python script simulating embedding that the logic redirects.

---
*PR created automatically by Jules for task [17516204337766487227](https://jules.google.com/task/17516204337766487227) started by @simpsoka*