### PR TITLE
🎨 Palette: Improve accessibility with `lang` attribute and visible focus states

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-14 - Improve screen reader accessibility and keyboard navigation
+**Learning:** `html` tags without a `lang` attribute break basic screen reader functionality, and custom UI components on dark backgrounds need explicit `:focus-visible` styles as default browser outlines often lack contrast and visibility.
+**Action:** Always verify `lang` is present on `html` tags and apply a high-contrast `:focus-visible` standard (`2px dashed #FFFFFF`, `4px` offset) to custom interactive elements against dark themes.

--- a/game.html
+++ b/game.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; style-src 'self' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self'; media-src 'self'; object-src 'none'; base-uri 'self'; form-action 'self';">
   <title>Jules Invaders</title>

--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; style-src 'self' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self'; media-src 'self'; object-src 'none'; base-uri 'self'; form-action 'self';">
   <title>Jules Invaders</title>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,0 +1,55 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      '@playwright/test':
+        specifier: ^1.56.0
+        version: 1.58.2
+      playwright:
+        specifier: ^1.56.1
+        version: 1.58.2
+
+packages:
+
+  '@playwright/test@1.58.2':
+    resolution: {integrity: sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
+  playwright-core@1.58.2:
+    resolution: {integrity: sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.58.2:
+    resolution: {integrity: sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+snapshots:
+
+  '@playwright/test@1.58.2':
+    dependencies:
+      playwright: 1.58.2
+
+  fsevents@2.3.2:
+    optional: true
+
+  playwright-core@1.58.2: {}
+
+  playwright@1.58.2:
+    dependencies:
+      playwright-core: 1.58.2
+    optionalDependencies:
+      fsevents: 2.3.2

--- a/style.css
+++ b/style.css
@@ -14,6 +14,11 @@ body {
   text-align: center;
 }
 
+button:focus-visible, a:focus-visible {
+  outline: 2px dashed #FFFFFF;
+  outline-offset: 4px;
+}
+
 canvas {
   background-color: #000;
   border: 2px solid #FFD700;


### PR DESCRIPTION
💡 **What:** 
- Added `lang="en"` to the `<html>` tag in `index.html` and `game.html`.
- Added `:focus-visible` styling (`2px dashed #FFFFFF` outline with `4px` outline-offset) for `button` and `a` elements in `style.css`.

🎯 **Why:** 
- Adding `lang="en"` ensures that screen readers and other assistive technologies can correctly pronounce and interpret the page content, improving fundamental accessibility.
- Default browser focus outlines are often difficult to see on completely dark backgrounds (`#000`). Adding a highly visible, contrasting `:focus-visible` style significantly improves keyboard navigation by clearly indicating which element has focus, without affecting mouse/touch users (which `:focus` would).

📸 **Before/After:** See the attached Playwright visual test verification screenshot where a clear white dashed box with a `4px` offset appears around focused buttons.

♿ **Accessibility:** This PR directly resolves two core WCAG requirements: specifying the language of the page (WCAG 3.1.1) and ensuring a visible focus indicator for keyboard users (WCAG 2.4.7).

---
*PR created automatically by Jules for task [7456772892047694697](https://jules.google.com/task/7456772892047694697) started by @simpsoka*