### PR TITLE
🛡️ Sentinel: [HIGH] Fix Clickjacking vulnerability

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -3,3 +3,8 @@
 **Vulnerability:** Game state corruption via unvalidated `localStorage` high score values (e.g., negative numbers, NaN).
 **Learning:** Data retrieved from client-side storage should be treated as untrusted user input and verified.
 **Prevention:** Use `parseInt(data, 10)` and apply proper validation checks (e.g., `!isNaN`, `value >= 0`) before using data retrieved from `localStorage`.
+
+## 2024-05-24 - Client-Side Framebusting for Static Sites
+**Vulnerability:** Clickjacking via embedding the site in an iframe.
+**Learning:** For static sites without server-configured HTTP headers, the CSP `frame-ancestors` directive is ignored when delivered via a `<meta>` tag, leaving the site vulnerable to UI redressing.
+**Prevention:** Implement client-side JavaScript framebusting (`if (window.top !== window.self) { window.top.location = window.self.location; }`) at the top of the main entry script to ensure the page cannot be framed.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,0 +1,55 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      '@playwright/test':
+        specifier: ^1.56.0
+        version: 1.58.2
+      playwright:
+        specifier: ^1.56.1
+        version: 1.58.2
+
+packages:
+
+  '@playwright/test@1.58.2':
+    resolution: {integrity: sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
+  playwright-core@1.58.2:
+    resolution: {integrity: sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.58.2:
+    resolution: {integrity: sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+snapshots:
+
+  '@playwright/test@1.58.2':
+    dependencies:
+      playwright: 1.58.2
+
+  fsevents@2.3.2:
+    optional: true
+
+  playwright-core@1.58.2: {}
+
+  playwright@1.58.2:
+    dependencies:
+      playwright-core: 1.58.2
+    optionalDependencies:
+      fsevents: 2.3.2

--- a/script.js
+++ b/script.js
@@ -1,3 +1,9 @@
+// --- Security: Framebusting to prevent Clickjacking ---
+// Necessary because CSP frame-ancestors is ignored when delivered via <meta> tags
+if (window.top !== window.self) {
+  window.top.location = window.self.location;
+}
+
 const canvas = document.getElementById("gameCanvas");
 const ctx = canvas.getContext("2d");
 const playAgainBtn = document.getElementById("playAgainBtn");


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** Clickjacking via embedding the site in an iframe. The existing CSP `frame-ancestors` directive is ineffective because it is delivered via a `<meta>` tag, which is ignored by browsers for this specific directive.
🎯 **Impact:** An attacker could embed the game in a malicious site and trick the user into performing unintended actions (like clicking "Play" or interacting with the game controls unknowingly).
🔧 **Fix:** Added client-side JavaScript framebusting (`if (window.top !== window.self) { window.top.location = window.self.location; }`) at the top of `script.js` to ensure the application always runs in the top-level window. Documented this finding in `.jules/sentinel.md`.
✅ **Verification:** Ran `npx playwright test` to ensure existing tests pass and the script still functions correctly. A manual verification would involve trying to load `index.html` or `game.html` within an `<iframe>` on a different page to confirm it breaks out of the frame.

---
*PR created automatically by Jules for task [4372328210883961517](https://jules.google.com/task/4372328210883961517) started by @simpsoka*