### PR TITLE
🎨 Palette: Add focus visible styles for keyboard accessibility

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,0 +1,55 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      '@playwright/test':
+        specifier: ^1.56.0
+        version: 1.58.2
+      playwright:
+        specifier: ^1.56.1
+        version: 1.58.2
+
+packages:
+
+  '@playwright/test@1.58.2':
+    resolution: {integrity: sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
+  playwright-core@1.58.2:
+    resolution: {integrity: sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.58.2:
+    resolution: {integrity: sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+snapshots:
+
+  '@playwright/test@1.58.2':
+    dependencies:
+      playwright: 1.58.2
+
+  fsevents@2.3.2:
+    optional: true
+
+  playwright-core@1.58.2: {}
+
+  playwright@1.58.2:
+    dependencies:
+      playwright-core: 1.58.2
+    optionalDependencies:
+      fsevents: 2.3.2

--- a/style.css
+++ b/style.css
@@ -124,3 +124,7 @@ h1 {
   background-color: #006400;
   color: #fff;
 }
+button:focus-visible, a:focus-visible {
+  outline: 2px dashed #FFFFFF;
+  outline-offset: 4px;
+}


### PR DESCRIPTION
💡 **What:** Added a `:focus-visible` style to `button` and `a` elements across the application.
🎯 **Why:** To significantly improve keyboard navigation accessibility. Previously, navigating the application using the "Tab" key provided no visual feedback against the dark background. The new dashed white outline makes it clear which interactive element currently has focus.
📸 **Before/After:** The "Play" button on `index.html` and the "Play Again" button on `game.html` now feature a clear `2px dashed #FFFFFF` outline when focused via keyboard navigation.
♿ **Accessibility:** This directly addresses WCAG 2.1 Success Criterion 2.4.7 Focus Visible, ensuring users who rely on keyboards can easily interact with the game menus.

---
*PR created automatically by Jules for task [14073829717580401120](https://jules.google.com/task/14073829717580401120) started by @simpsoka*