### PR TITLE
🛡️ Sentinel: [HIGH] Fix clickjacking vulnerability

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -3,3 +3,8 @@
 **Vulnerability:** Game state corruption via unvalidated `localStorage` high score values (e.g., negative numbers, NaN).
 **Learning:** Data retrieved from client-side storage should be treated as untrusted user input and verified.
 **Prevention:** Use `parseInt(data, 10)` and apply proper validation checks (e.g., `!isNaN`, `value >= 0`) before using data retrieved from `localStorage`.
+
+## 2024-05-24 - Framebusting for Clickjacking Mitigation
+**Vulnerability:** Clickjacking (UI redressing) vulnerabilities due to lack of server-side HTTP headers.
+**Learning:** For static applications that lack server-side HTTP response header configurations, the CSP `frame-ancestors` directive cannot be enforced via `<meta>` tags.
+**Prevention:** Implement client-side JavaScript framebusting logic (`if (window.top !== window.self) { window.top.location = window.self.location; }`) at the top of the main script.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,0 +1,55 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      '@playwright/test':
+        specifier: ^1.56.0
+        version: 1.58.2
+      playwright:
+        specifier: ^1.56.1
+        version: 1.58.2
+
+packages:
+
+  '@playwright/test@1.58.2':
+    resolution: {integrity: sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
+  playwright-core@1.58.2:
+    resolution: {integrity: sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.58.2:
+    resolution: {integrity: sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+snapshots:
+
+  '@playwright/test@1.58.2':
+    dependencies:
+      playwright: 1.58.2
+
+  fsevents@2.3.2:
+    optional: true
+
+  playwright-core@1.58.2: {}
+
+  playwright@1.58.2:
+    dependencies:
+      playwright-core: 1.58.2
+    optionalDependencies:
+      fsevents: 2.3.2

--- a/script.js
+++ b/script.js
@@ -1,3 +1,9 @@
+// --- Security: Framebusting to prevent Clickjacking ---
+// CSP frame-ancestors is ignored in <meta> tags, so we use JS for static apps
+if (window.top !== window.self) {
+  window.top.location = window.self.location;
+}
+
 const canvas = document.getElementById("gameCanvas");
 const ctx = canvas.getContext("2d");
 const playAgainBtn = document.getElementById("playAgainBtn");


### PR DESCRIPTION
**🚨 Severity:** HIGH
**💡 Vulnerability:** The game lacks server-side HTTP headers to enforce `X-Frame-Options` or CSP `frame-ancestors`, leaving it vulnerable to Clickjacking (UI redressing) attacks when embedded in malicious iframes. CSP `frame-ancestors` does not work when deployed via `<meta>` tags.
**🎯 Impact:** An attacker could embed the game in an invisible iframe and trick users into clicking on malicious overlays, potentially hijacking input or exploiting user interactions.
**🔧 Fix:** Implemented standard client-side JavaScript framebusting logic at the beginning of `script.js`. If the game is loaded in an iframe (`window.top !== window.self`), it forces the top window to redirect to the game's URL.
**✅ Verification:** 
- The game loads correctly when accessed directly.
- Running `node -c script.js` confirms no syntax errors.
- Running `npx playwright test` confirms the CSP and performance tests continue to pass without regressions.

---
*PR created automatically by Jules for task [16657717049079579682](https://jules.google.com/task/16657717049079579682) started by @simpsoka*